### PR TITLE
Add CSS and configuration support for subtle pagenames

### DIFF
--- a/conf/default.php
+++ b/conf/default.php
@@ -14,3 +14,5 @@ $conf["feedbackBody"] = "Thank you so much for taking the time to write feedback
 $conf["hiddenActions"] = "backlink,top";
 
 $conf["protrudingDrawer"] = 1;
+
+$conf["subtlePagename"] = 0;

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -14,3 +14,5 @@ $meta['feedbackBody'] = array('string');
 $meta['hiddenActions']  = array('multicheckbox','_choices' => array('edit','revs','backlink','export_pdf','top'));
 
 $meta['protrudingDrawer'] = array('onoff');
+
+$meta['subtlePagename'] = array('onoff');

--- a/css/basic.less
+++ b/css/basic.less
@@ -262,6 +262,14 @@ body {
   }
 }
 
+.pagename-bar {
+  padding: 1em;
+  background-color: @primary;
+  color: @light_primary;
+  text-transform: lowercase;
+  font-weight: bold;
+}
+
 .content-card__text {
   padding: 2em;
   padding-top: 0.5em;


### PR DESCRIPTION
This PR begins adding support for subtle pagenames. It does so by defining a CSS class, `.pagename-bar` in `basic.less`. It also adds a new configuration option, `subtlePagename`, which is set to 0 by default. The CSS uses the primary color for the theme as the background of the page title bar.

What's left, as far as I can tell, is to edit `main.php`, specifically this section:

```
<?php if ($ACT == "show"): ?>
                    <div class="content-card__title">
                        <h1><?php
                            if ($conf["youarehere"]) {
                                echo ucfirst(tpl_pagetitle(null, true));
                            }else echo ucfirst($ID);
                            ?></h1>
                    </div>
                <?php endif?>
```
I want to add a conditional that checks for the value of `$conf["subtlePagename"]`. If it's `1`, it adds the class `pagename-bar` to the classes of this div, and instead of `<h1>` tags, just uses a `<span>` or something like that, because the text is not intended as a top-level header. If `$conf["subtlePagename"] = 0`, then it just renders as normal, no change from the above.

However, my PHP is not good, so I'm not sure I can cleanly make this happen. I'm open to assistance.