### PR TITLE
feat: add different behavior for missing links

### DIFF
--- a/css/basic.less
+++ b/css/basic.less
@@ -15,17 +15,6 @@ body {
 }
 
 .page-content {
-  a,
-  a:link,
-  a:active,
-  a:visited,
-  a:hover {
-    color: #3986dd;
-    text-decoration: none;
-  }
-  a:hover {
-    text-decoration: underline;
-  }
   h1, h2, h3, h4, h5, h6 {
     //TODO: nice heading styles
   }

--- a/css/links.less
+++ b/css/links.less
@@ -29,9 +29,7 @@
     background-color: inherit;
   }
   a.wikilink2:link,
-  a.wikilink2:visited {
-    border-bottom: 1px dashed;
-  }
+  a.wikilink2:visited,
   a.wikilink2:hover,
   a.wikilink2:active,
   a.wikilink2:focus {

--- a/css/links.less
+++ b/css/links.less
@@ -1,0 +1,67 @@
+.page-content {
+  a,
+  a:link,
+  a:active,
+  a:visited,
+  a:hover {
+    color: @ini_link;
+    text-decoration: none;
+  }
+  a:hover {
+    text-decoration: underline;
+  }
+  /* existing wikipage */
+  a.wikilink1,
+  a.wikilink1:link,
+  a.wikilink1:active,
+  a.wikilink1:visited,
+  a.wikilink1:hover {
+    color: @ini_existing;
+    background-color: inherit;
+  }
+  /* not existing wikipage */
+  a.wikilink2,
+  a.wikilink2:link,
+  a.wikilink2:active,
+  a.wikilink2:visited,
+  a.wikilink2:hover {
+    color: @ini_missing;
+    background-color: inherit;
+  }
+  a.wikilink2:link,
+  a.wikilink2:visited {
+    border-bottom: 1px dashed;
+  }
+  a.wikilink2:hover,
+  a.wikilink2:active,
+  a.wikilink2:focus {
+    border-bottom-width: 0;
+  }
+
+  /* any link to current page */
+  span.curid a {
+    font-weight: bold;
+  }
+
+  a.urlextern,
+  a.windows,
+  a.mail,
+  a.mediafile,
+  a.interwiki {
+    background-repeat: no-repeat;
+    background-position: 0 center;
+    padding: 0 0 0 18px;
+  }
+  /* external link */
+  a.urlextern {
+    background-image: url(../../images/external-link.png);
+  }
+  /* windows share */
+  a.windows {
+    background-image: url(../../images/unc.png);
+  }
+  /* email link */
+  a.mail {
+    background-image: url(../../images/email.png);
+  }
+}

--- a/style.ini
+++ b/style.ini
@@ -1,6 +1,7 @@
 [stylesheets]
 
 css/comp.less                          = all
+css/links.less                         = all
 css/basic.less                         = all
 css/fixes.less                         = all
 css/editor.less                        = all
@@ -27,37 +28,37 @@ css/mobile.less                        = screen
 ; Blue grey - Red
   __primary__         = "#455A64"             ; @ini_primary
   __primary_dark__    = "#1C313A"             ; @ini_primary_dark
-  __accent_           = "#C62828"             ; @ini_accent
+  __accent__          = "#C62828"             ; @ini_accent
 
 ; Blue grey - Yellow
 ;  __primary__         = "#455A64"             ; @ini_primary
 ;  __primary_dark__    = "#1C313A"             ; @ini_primary_dark
-;  __accent_           = "#FBC02D"             ; @ini_accent
+;  __accent__          = "#FBC02D"             ; @ini_accent
 
 ; Light grey - Red
 ;  __primary__         = "#607D8B"             ; @ini_primary
 ;  __primary_dark__    = "#34515E"             ; @ini_primary_dark
-;  __accent_           = "#C62828"             ; @ini_accent
+;  __accent__          = "#C62828"             ; @ini_accent
 
 ; Deep blue - Orange
 ;  __primary__         = "#1a237e"             ; @ini_primary
 ;  __primary_dark__    = "#181F69"             ; @ini_primary_dark
-;  __accent_           = "#FB8C00"             ; @ini_accent
+;  __accent__          = "#FB8C00"             ; @ini_accent
 
 ; Blue - Orange
 ;  __primary__         = "#1976D2"             ; @ini_primary
 ;  __primary_dark__    = "#003C8F"             ; @ini_primary_dark
-;  __accent_           = "#FBC02D"             ; @ini_accent
+;  __accent__          = "#FBC02D"             ; @ini_accent
 
 ; Blue - Pink
 ;  __primary__         = "#3F61b5"             ; @ini_primary
-; __primary_dark__    = "#303f9f"             ; @ini_primary_dark
-;  __accent_           = "#ff4081"             ; @ini_accent
+;  __primary_dark__    = "#303f9f"             ; @ini_primary_dark
+;  __accent__          = "#ff4081"             ; @ini_accent
 
 ; Green - Yellow
 ;  __primary__         = "#009688"             ; @ini_primary
 ;  __primary_dark__    = "#00675B"             ; @ini_primary_dark
-;  __accent_           = "#FBC02D"             ; @ini_accent
+;  __accent__          = "#FBC02D"             ; @ini_accent
 
 
 
@@ -66,7 +67,7 @@ css/mobile.less                        = screen
 ; Custom
 ;  __primary__         = "#262626"             ; @ini_primary
 ;  __primary_dark__    = "#000000"             ; @ini_primary_dark
-;  __accent_           = "#fca800"             ; @ini_accent
+;  __accent__          = "#fca800"             ; @ini_accent
 
 
 
@@ -99,8 +100,9 @@ __highlight__      = "#ff9"                 ; @ini_highlight
 
 
 ; Link styling
-__existing__       = "#c00"                 ; @ini_existing
-__missing__        = "#f30"                 ; @ini_missing
+__link__           = "#3986dd"              ; @ini_link
+__existing__       = "#3986dd"              ; @ini_existing
+__missing__        = "#d30"                 ; @ini_missing
 
 ; widths
 __site_width__     = "64em"                 ; @ini_site_width


### PR DESCRIPTION
This PR adds the possibility to assign different colors to missing and existing links, and a few things that I have taken from [the official dokuwiki theme](https://github.com/splitbrain/dokuwiki/blob/master/lib/tpl/dokuwiki/css/_links.css) : dashed underline for missing links, bold for links to current page and icons for particular links (urlextern, windows, mail).

If there are too many things I can remove some of them.

closes #41 