### PR TITLE
feat: make pre tags more visible

### DIFF
--- a/css/basic.less
+++ b/css/basic.less
@@ -26,6 +26,29 @@ body {
   a:hover {
     text-decoration: underline;
   }
+
+  pre,
+  code,
+  samp,
+  kbd {
+      font-family: Consolas, "Andale Mono WT", "Andale Mono", "Bitstream Vera Sans Mono", "Nimbus Mono L", Monaco, "Courier New", monospace;
+      font-size: 1em;
+      direction: ltr;
+      text-align: left;
+      background-color: @ini_background_site;
+      color: @ini_text;
+      box-shadow: inset 0 0 .3em @ini_border;
+      border-radius: 2px;
+  }
+  pre {
+      overflow: auto;
+      word-wrap: normal;
+      border: 1px solid @ini_border;
+      border-radius: 2px;
+      box-shadow: inset 0 0 .5em @ini_border;
+      padding: .7em 1em;
+  }
+
   h1, h2, h3, h4, h5, h6 {
     //TODO: nice heading styles
   }

--- a/css/basic.less
+++ b/css/basic.less
@@ -31,21 +31,17 @@ body {
   code,
   samp,
   kbd {
-      font-family: Consolas, "Andale Mono WT", "Andale Mono", "Bitstream Vera Sans Mono", "Nimbus Mono L", Monaco, "Courier New", monospace;
+      font-family: Consolas,Menlo,Monaco,Lucida Console,Liberation Mono,DejaVu Sans Mono,Bitstream Vera Sans Mono,Courier New,monospace,sans-serif;
       font-size: 1em;
       direction: ltr;
       text-align: left;
-      background-color: @ini_background_site;
+      background-color: @ini_code_background;
       color: @ini_text;
-      box-shadow: inset 0 0 .3em @ini_border;
-      border-radius: 2px;
   }
   pre {
       overflow: auto;
       word-wrap: normal;
-      border: 1px solid @ini_border;
-      border-radius: 2px;
-      box-shadow: inset 0 0 .5em @ini_border;
+      line-height: 1.3;
       padding: .7em 1em;
   }
 

--- a/style.ini
+++ b/style.ini
@@ -97,6 +97,7 @@ __border__         = "#ccc"                 ; @ini_border
 ; highlighted text (e.g. search snippets)
 __highlight__      = "#ff9"                 ; @ini_highlight
 
+__background_site__ = "#fdfcfb"             ; @ini_background_site
 
 ; Link styling
 __existing__       = "#c00"                 ; @ini_existing

--- a/style.ini
+++ b/style.ini
@@ -94,6 +94,9 @@ __background_neu__ = "#ddd"                 ; @ini_background_neu
 ; border color
 __border__         = "#ccc"                 ; @ini_border
 
+; background for code, pre tags
+__code_background__ = "#eff0f1"             ; @ini_code_background
+
 ; highlighted text (e.g. search snippets)
 __highlight__      = "#ff9"                 ; @ini_highlight
 

--- a/style.ini
+++ b/style.ini
@@ -100,8 +100,6 @@ __code_background__ = "#eff0f1"             ; @ini_code_background
 ; highlighted text (e.g. search snippets)
 __highlight__      = "#ff9"                 ; @ini_highlight
 
-__background_site__ = "#fdfcfb"             ; @ini_background_site
-
 ; Link styling
 __existing__       = "#c00"                 ; @ini_existing
 __missing__        = "#f30"                 ; @ini_missing


### PR DESCRIPTION
Here I have taken again some code from the official dokuwiki theme [here](https://github.com/splitbrain/dokuwiki/blob/master/lib/tpl/dokuwiki/css/basic.less#L263).

It's not that bad I think. If you would like something that looks differently for this theme why not, but I think it's at least better than the current styling which is the same as normal text.

closes #45 