### PR TITLE
fix: make small wiki pages occupy normal height from the beginning

### DIFF
--- a/css/fixes.less
+++ b/css/fixes.less
@@ -55,6 +55,10 @@ a {
   height: 100vh;
 }
 
+.mdl-layout.mdl-js-layout{
+  min-height: 100vh;
+}
+
 .mdl-layout-title {
   flex-shrink: 1;
   overflow: hidden;


### PR DESCRIPTION
I'm not sure it's the best way to do it, but this hack solves the bug without removing the `defer`.

closes #50 