### PR TITLE
fix: typo on css rule making table rows center align

### DIFF
--- a/css/basic.less
+++ b/css/basic.less
@@ -112,7 +112,7 @@ body {
     vertical-align:middle;
     font-size:1em;
 
-    &.centralign {
+    &.centeralign {
       text-align: center;
     }
     &.rightalign {


### PR DESCRIPTION
I made a little error in my previous PR, center alignment is not working on tables because of that.